### PR TITLE
Try to make the representer work on v3 staging website

### DIFF
--- a/lib/representer.ex
+++ b/lib/representer.ex
@@ -31,21 +31,28 @@ defmodule Representer do
 
   def add_meta(node), do: node
 
-  def exchange({:defmodule, [line: x], [{:__aliases__, [line: x], [module_name]} = module_alias | _] = args} = node, represented) do
+  def exchange(
+        {:defmodule, [line: x],
+         [{:__aliases__, [line: x], [module_name]} = module_alias | _] = args} = node,
+        represented
+      ) do
     {:ok, represented, mapped_term} = Mapping.get_placeholder(represented, module_name, :module)
 
     module_alias = module_alias |> Tuple.delete_at(2) |> Tuple.append([mapped_term])
-    args = [module_alias | (args |> tl)]
+    args = [module_alias | args |> tl]
     node = node |> Tuple.delete_at(2) |> Tuple.append(args)
 
     {node, represented}
   end
 
   def exchange({:def, _, [{function_name, _, _} = function_head | _] = args} = node, represented) do
-    {:ok, represented, mapped_function_name} = Representer.Mapping.get_placeholder(represented, function_name)
+    {:ok, represented, mapped_function_name} =
+      Representer.Mapping.get_placeholder(represented, function_name)
 
-    function_head = function_head |> Tuple.delete_at(0) |> Tuple.insert_at(0, mapped_function_name)
-    args = [function_head | (args |> tl)]
+    function_head =
+      function_head |> Tuple.delete_at(0) |> Tuple.insert_at(0, mapped_function_name)
+
+    args = [function_head | args |> tl]
     node = node |> Tuple.delete_at(2) |> Tuple.append(args)
 
     {node, represented}
@@ -75,11 +82,13 @@ defmodule Representer do
 
     {:__block__, meta, children}
   end
+
   def drop_docstring(node), do: node
 
   def drop_line_meta({marker, metadata, children}) do
     metadata = Keyword.drop(metadata, [:line])
     {marker, metadata, children}
   end
+
   def drop_line_meta(node), do: node
 end

--- a/lib/representer/cli.ex
+++ b/lib/representer/cli.ex
@@ -11,7 +11,7 @@ defmodule Representer.CLI do
     output_path = Path.absname(output_path)
     concatenated_input_file_path = Path.join([input_path, @concatenated_file])
 
-    # get all .ex files
+    # get all .ex files, put the exercise file last
     files =
       File.ls!(input_path)
       |> Enum.filter(fn f -> String.ends_with?(f, ".ex") && f != @concatenated_file end)

--- a/lib/representer/cli.ex
+++ b/lib/representer/cli.ex
@@ -13,12 +13,12 @@ defmodule Representer.CLI do
 
     # get all .ex files, put the exercise file last
     files =
-      File.ls!(input_path)
-      |> Enum.filter(fn f -> String.ends_with?(f, ".ex") && f != @concatenated_file end)
+      Path.wildcard(Path.join([input_path, "**", "*.ex"]))
+      |> Enum.filter(fn f -> !String.ends_with?(f, @concatenated_file) end)
       |> Enum.sort_by(fn f -> f == "#{exercise}.ex" end)
 
     # join all of the files
-    concatenated = Enum.map_join(files, "\n", fn f -> File.read!(Path.join([input_path, f])) end)
+    concatenated = Enum.map_join(files, "\n", fn f -> File.read!(f) end)
 
     File.write!(concatenated_input_file_path, concatenated)
 

--- a/test/representer_test.exs
+++ b/test/representer_test.exs
@@ -2,12 +2,18 @@ defmodule RepresenterTest do
   use ExUnit.Case
 
   test "run" do
-    File.mkdir!("./test_output")
+    File.mkdir_p!("./test_output")
 
     Representer.process(
       "./test_data/hello_world.ex",
       "./test_output/representation.txt",
       "./test_output/mapping.json"
     )
+
+    assert File.read!("./test_output/representation.txt") ==
+             File.read!("./test_data/expected_representation.txt")
+
+    assert File.read!("./test_output/mapping.json") ==
+             File.read!("./test_data/expected_mapping.json")
   end
 end

--- a/test_data/expected_mapping.json
+++ b/test_data/expected_mapping.json
@@ -1,0 +1,16 @@
+{
+  "PLACEHOLDER_1": "HelloWorld",
+  "PLACEHOLDER_10": "var",
+  "PLACEHOLDER_11": "check_expand_do",
+  "PLACEHOLDER_12": "TestMultiple",
+  "PLACEHOLDER_13": "test",
+  "PLACEHOLDER_14": "PLACEHOLDER_13",
+  "PLACEHOLDER_2": "hello",
+  "PLACEHOLDER_3": "name",
+  "PLACEHOLDER_4": "add_then_subtract",
+  "PLACEHOLDER_5": "n",
+  "PLACEHOLDER_6": "a",
+  "PLACEHOLDER_7": "s",
+  "PLACEHOLDER_8": "total",
+  "PLACEHOLDER_9": "check_case"
+}

--- a/test_data/expected_representation.txt
+++ b/test_data/expected_representation.txt
@@ -1,0 +1,120 @@
+{:__block__, [],
+ [
+   {:defmodule, [],
+    [
+      {:__aliases__, [], [:PLACEHOLDER_1]},
+      [
+        do: {:__block__, [],
+         [
+           {:def, [],
+            [
+              {:PLACEHOLDER_2, [],
+               [{:\\, [], [{:PLACEHOLDER_3, [], nil}, "world"]}]},
+              [
+                do: {:<<>>, [],
+                 [
+                   "Hello, ",
+                   {:"::", [],
+                    [
+                      {{:., [], [Kernel, :to_string]}, [],
+                       [{:PLACEHOLDER_3, [], nil}]},
+                      {:binary, [binary_helper: true], nil}
+                    ]}
+                 ]}
+              ]
+            ]},
+           {:@, [],
+            [
+              {:spec, [],
+               [
+                 {:"::", [],
+                  [
+                    {:add_then_subtract, [],
+                     [
+                       {:integer, [], []},
+                       {:integer, [], []},
+                       {:integer, [], []}
+                     ]},
+                    {:integer, [], []}
+                  ]}
+               ]}
+            ]},
+           {:def, [],
+            [
+              {:PLACEHOLDER_4, [],
+               [
+                 {:PLACEHOLDER_5, [], nil},
+                 {:PLACEHOLDER_6, [], nil},
+                 {:PLACEHOLDER_7, [], nil}
+               ]},
+              [
+                do: {:__block__, [],
+                 [
+                   {:=, [],
+                    [
+                      {:PLACEHOLDER_8, [], nil},
+                      {:+, [],
+                       [{:PLACEHOLDER_5, [], nil}, {:PLACEHOLDER_6, [], nil}]}
+                    ]},
+                   {:-, [],
+                    [{:PLACEHOLDER_8, [], nil}, {:PLACEHOLDER_7, [], nil}]}
+                 ]}
+              ]
+            ]},
+           {:def, [],
+            [
+              {:PLACEHOLDER_9, [], [{:PLACEHOLDER_10, [], nil}]},
+              [
+                do: {:case, [],
+                 [
+                   {:PLACEHOLDER_10, [], nil},
+                   [
+                     do: [
+                       {:->, [],
+                        [
+                          [
+                            {:when, [],
+                             [
+                               {:PLACEHOLDER_10, [], nil},
+                               {:is_bitstring, [], [{:PLACEHOLDER_10, [], nil}]}
+                             ]}
+                          ],
+                          :string
+                        ]},
+                       {:->, [],
+                        [
+                          [
+                            {:when, [],
+                             [
+                               {:PLACEHOLDER_10, [], nil},
+                               {:is_number, [], [{:PLACEHOLDER_10, [], nil}]}
+                             ]}
+                          ],
+                          :number
+                        ]},
+                       {:->, [],
+                        [
+                          [
+                            {:when, [],
+                             [
+                               {:PLACEHOLDER_10, [], nil},
+                               {:is_boolean, [], [{:PLACEHOLDER_10, [], nil}]}
+                             ]}
+                          ],
+                          :boolean
+                        ]}
+                     ]
+                   ]
+                 ]}
+              ]
+            ]},
+           {:def, [], [{:PLACEHOLDER_11, [], []}, [do: true]]}
+         ]}
+      ]
+    ]},
+   {:defmodule, [],
+    [
+      {:__aliases__, [], [:PLACEHOLDER_12]},
+      [do: {:def, [], [{:PLACEHOLDER_14, [], nil}, [do: :test]]}]
+    ]}
+ ]}


### PR DESCRIPTION
If you go to https://exercism.lol/maintaining/exercise_representations and take a look at any of the Elixir submissions, you'll notice that they all have the same empty representation:

```
{:__block__, [], []}
```

This is because the solution path passed to the representer points to the mix project, but the actual files are inside of the `lib` directory of the mix project.

This PR:
- Edits `lib/representer/cli.ex` to look for files in `lib`
- Edits `lib/representer/cli.ex` not to hop between directories but use absolute paths for reading and writing files
- Runs `mix format` on `lib/representer.ex`, no other changes there.
- Adds some assertion to the test file because so far it didn't test anything... I'm not sure what was the original intention there.