### PR TITLE
Normalizing multi-component modules and module aliases

### DIFF
--- a/lib/representer.ex
+++ b/lib/representer.ex
@@ -92,10 +92,10 @@ defmodule Representer do
   # variables
   # https://elixir-lang.org/getting-started/meta/quote-and-unquote.html
   # "The third element is either a list of arguments for the function call or an atom. When this element is an atom, it means the tuple represents a variable."
-  @special_var_names [:__CALLER__, :__DIR__, :__ENV__, :__MODULE__, :__STACKTRACE__, :...]
+  @special_var_names [:__CALLER__, :__DIR__, :__ENV__, :__MODULE__, :__STACKTRACE__, :..., :_]
   defp do_define_placeholders({atom, meta, context}, represented)
        when is_atom(atom) and is_nil(context) and atom not in @special_var_names do
-    {:ok, represented, mapped_term} = Representer.Mapping.get_placeholder(represented, atom)
+    {:ok, represented, mapped_term} = Mapping.get_placeholder(represented, atom)
 
     {{mapped_term, meta, context}, represented}
   end

--- a/lib/representer/mapping.ex
+++ b/lib/representer/mapping.ex
@@ -27,7 +27,18 @@ defmodule Representer.Mapping do
     %Mapping{}
   end
 
-  def get_placeholder(%Mapping{} = map, term, _type \\ :term) do
+  def get_placeholder(%Mapping{} = map, terms) when is_list(terms) do
+    {map, names} =
+      Enum.reduce(terms, {map, []}, fn
+        name, {map, names} ->
+          {:ok, map, name} = Mapping.get_placeholder(map, name)
+          {map, [name | names]}
+      end)
+
+    {:ok, map, Enum.reverse(names)}
+  end
+
+  def get_placeholder(%Mapping{} = map, term) do
     if map.mappings[term] do
       {:ok, map, map.mappings[term]}
     else

--- a/test/representer_test.exs
+++ b/test/representer_test.exs
@@ -29,6 +29,9 @@ defmodule RepresenterTest do
     test "parentheses_in_pipes" do
       test_directory("parentheses_in_pipes")
     end
+    test "modules" do
+      test_directory("modules")
+    end
   end
 
   defp test_directory(dir) do

--- a/test_data/modules/expected_mapping.json
+++ b/test_data/modules/expected_mapping.json
@@ -1,0 +1,16 @@
+{
+  "Placeholder_1": "One",
+  "Placeholder_10": "Ten",
+  "Placeholder_11": "Eleven",
+  "Placeholder_12": "Twelve",
+  "Placeholder_13": "Thirteen",
+  "Placeholder_2": "Two",
+  "Placeholder_5": "Five",
+  "Placeholder_6": "Six",
+  "Placeholder_7": "Seven",
+  "Placeholder_8": "Eight",
+  "placeholder_14": "fourteen",
+  "placeholder_3": "three",
+  "placeholder_4": "four",
+  "placeholder_9": "nine"
+}

--- a/test_data/modules/expected_representation.txt
+++ b/test_data/modules/expected_representation.txt
@@ -1,0 +1,38 @@
+(
+  defmodule(Placeholder_1) do
+    alias(Placeholder_1, as: Placeholder_2)
+    def(placeholder_3) do
+      Placeholder_1.placeholder_4()
+      Placeholder_2.placeholder_4()
+    end
+    def(placeholder_4) do
+      :ok
+    end
+  end
+  defmodule(Placeholder_5.Placeholder_6.Placeholder_7) do
+    alias(Placeholder_5.Placeholder_6, as: Placeholder_8)
+    def(placeholder_9) do
+      Placeholder_1.placeholder_3()
+      Placeholder_2.placeholder_3()
+      Placeholder_5.Placeholder_6.Placeholder_7.placeholder_9()
+      Placeholder_8.Placeholder_7.placeholder_9()
+      __MODULE__.placeholder_9()
+      External.external()
+      Placeholder_1.External.external()
+      Placeholder_5.External.Placeholder_7.nine()
+    end
+    defmodule(Placeholder_10) do
+      
+    end
+    defmodule(Placeholder_11) do
+      alias(Placeholder_5.Placeholder_6.Placeholder_7.{Placeholder_10, Placeholder_11})
+      alias(Placeholder_8.Placeholder_7.Placeholder_11, as: Placeholder_12)
+      alias(Placeholder_8.Placeholder_7, as: Placeholder_2)
+      alias(External, as: Placeholder_13)
+      def(placeholder_14) do
+        External.external()
+        Placeholder_13.external()
+      end
+    end
+  end
+)

--- a/test_data/modules/input.ex
+++ b/test_data/modules/input.ex
@@ -1,0 +1,45 @@
+defmodule One do
+  alias One, as: Two
+
+  def three do
+    One.four()
+    Two.four()
+  end
+
+  def four, do: :ok
+end
+
+defmodule Five.Six.Seven do
+  alias Five.Six, as: Eight
+
+  def nine do
+    One.three()
+    Two.three()
+
+    Five.Six.Seven.nine()
+    Eight.Seven.nine()
+    __MODULE__.nine()
+    # not replaced
+    External.external()
+    # only :One is replaced
+    One.External.external()
+    # nine not replaced because of External
+    Five.External.Seven.nine()
+  end
+
+  defmodule Ten do
+  end
+
+  defmodule Eleven do
+    alias Five.Six.Seven.{Ten, Eleven}
+    alias Eight.Seven.Eleven, as: Twelve
+    alias Eight.Seven, as: Two
+
+    alias External, as: Thirteen
+
+    def fourteen do
+      External.external()
+      Thirteen.external()
+    end
+  end
+end

--- a/test_data/special_variables/expected_representation.txt
+++ b/test_data/special_variables/expected_representation.txt
@@ -5,7 +5,7 @@ defmodule(Placeholder_1) do
     :math.pow(__DIR__)
     placeholder_6.(__ENV__)
   end
-  defmacro(placeholder_7()) do
+  defmacro(placeholder_7(_)) do
     placeholder_2(__CALLER__, __STACKTRACE__)
     placeholder_8 = 3
   end

--- a/test_data/special_variables/input.ex
+++ b/test_data/special_variables/input.ex
@@ -6,7 +6,7 @@ defmodule AnythingAndEverything do
     some_value.(__ENV__)
   end
 
-  defmacro foo() do
+  defmacro foo(_) do
     some_function(__CALLER__, __STACKTRACE__)
     _ignored = 3
   end


### PR DESCRIPTION
Closes #43 (first commit).
Closes #33.
Addresses the `alias` part of #40. I haven't done the `import` yet, this PR is big enough as it is.

I also slightly modified `represent` so that it's easier to test inputs with `iex`.