### PR TITLE
Fix errors for all dancing-dots submissions

### DIFF
--- a/lib/representer.ex
+++ b/lib/representer.ex
@@ -197,7 +197,8 @@ defmodule Representer do
     {{:., meta, path}, meta2, args}
   end
 
-  defp remove_type_parentheses({type, meta, args}) when args == [] or is_atom(args) do
+  defp remove_type_parentheses({type, meta, args})
+       when type != :%{} and (args == [] or is_atom(args)) do
     meta = Keyword.put(meta, :type?, true)
     {type, meta, nil}
   end

--- a/test_data/user_defined_structs/expected_mapping.json
+++ b/test_data/user_defined_structs/expected_mapping.json
@@ -1,11 +1,12 @@
 {
-  "Placeholder_1": "Car",
-  "Placeholder_2": "VroomVroom",
-  "Placeholder_3": "Automobile",
-  "placeholder_4": "create",
-  "placeholder_5": "color",
-  "placeholder_6": "repaint",
-  "placeholder_7": "car",
-  "placeholder_8": "fake_create",
-  "placeholder_9": "authorize_driver"
+  "Placeholder_2": "Car",
+  "Placeholder_3": "VroomVroom",
+  "Placeholder_4": "Automobile",
+  "placeholder_1": "t",
+  "placeholder_10": "authorize_driver",
+  "placeholder_5": "create",
+  "placeholder_6": "color",
+  "placeholder_7": "repaint",
+  "placeholder_8": "car",
+  "placeholder_9": "fake_create"
 }

--- a/test_data/user_defined_structs/expected_representation.ex
+++ b/test_data/user_defined_structs/expected_representation.ex
@@ -1,5 +1,6 @@
 defmodule Placeholder_1 do
   defstruct [:wheels, :doors, :color]
+  @type t :: %__MODULE__{}
 end
 
 defmodule Placeholder_2 do

--- a/test_data/user_defined_structs/expected_representation.ex
+++ b/test_data/user_defined_structs/expected_representation.ex
@@ -1,29 +1,29 @@
-defmodule Placeholder_1 do
+defmodule Placeholder_2 do
   defstruct [:wheels, :doors, :color]
-  @type t :: %__MODULE__{}
+  @type placeholder_1 :: %__MODULE__{}
 end
 
-defmodule Placeholder_2 do
+defmodule Placeholder_3 do
   defstruct [:cars, :driving_licence]
-  alias Placeholder_1, as: Placeholder_3
+  alias Placeholder_2, as: Placeholder_4
 
-  def placeholder_4(placeholder_5) do
-    %Placeholder_1{color: placeholder_5, doors: 2, wheels: 4}
+  def placeholder_5(placeholder_6) do
+    %Placeholder_2{color: placeholder_6, doors: 2, wheels: 4}
   end
 
-  def placeholder_6(placeholder_7, placeholder_5) do
-    %Placeholder_3{
-      placeholder_7
-      | color: placeholder_5,
-        driving_licence: placeholder_7.driving_licence
+  def placeholder_7(placeholder_8, placeholder_6) do
+    %Placeholder_4{
+      placeholder_8
+      | color: placeholder_6,
+        driving_licence: placeholder_8.driving_licence
     }
   end
 
-  def placeholder_8(placeholder_5) do
-    %{color: placeholder_5, doors: 2, wheels: 4}
+  def placeholder_9(placeholder_6) do
+    %{color: placeholder_6, doors: 2, wheels: 4}
   end
 
-  def placeholder_9() do
+  def placeholder_10() do
     %__MODULE__{cars: nil, driving_licence: "I can totally drive a car"}
   end
 end

--- a/test_data/user_defined_structs/lib/input.ex
+++ b/test_data/user_defined_structs/lib/input.ex
@@ -1,5 +1,6 @@
 defmodule Car do
   defstruct [:wheels, :doors, :color]
+  @type t :: %__MODULE__{}
 end
 
 defmodule VroomVroom do


### PR DESCRIPTION
Resolves https://github.com/exercism/elixir-representer/issues/96

In a separate PR, I would love to add some sort of smoke test that would run the formatter for every real exercise and check that it produced a representation. It would require to correctly include the exemplar solution + extra files ( just the exemplar doesn't cause a crash for dancing-dots), or maybe just run it on an empty solution? Not sure.