### PR TITLE
Fix handling function references

### DIFF
--- a/lib/representer/mapping.ex
+++ b/lib/representer/mapping.ex
@@ -75,6 +75,6 @@ defmodule Representer.Mapping do
 
   defp capitalized?(term) do
     first = term |> to_string |> String.first()
-    first != "_" and first == String.upcase(first)
+    first != String.downcase(first) and first == String.upcase(first)
   end
 end

--- a/test/representer_test.exs
+++ b/test/representer_test.exs
@@ -57,6 +57,10 @@ defmodule RepresenterTest do
     test "import_order" do
       test_directory("import_order")
     end
+
+    test "function_references" do
+      test_directory("function_references")
+    end
   end
 
   defp test_directory(dir) do

--- a/test_data/function_references/expected_mapping.json
+++ b/test_data/function_references/expected_mapping.json
@@ -1,0 +1,8 @@
+{
+  "Placeholder_2": "Foo",
+  "placeholder_1": "func",
+  "placeholder_3": "bar",
+  "placeholder_4": "x",
+  "placeholder_5": "y",
+  "placeholder_6": "baz"
+}

--- a/test_data/function_references/expected_representation.ex
+++ b/test_data/function_references/expected_representation.ex
@@ -1,0 +1,29 @@
+placeholder_1 = &is_integer/1
+true = is_integer(3)
+placeholder_1 = &Kernel.is_integer/1
+true = Kernel.is_integer(3)
+placeholder_1 = &+/2
+5 = 2 + 3
+placeholder_1 = &Kernel.+/2
+5 = Kernel.+(2, 3)
+placeholder_1 = &*/2
+10 = 5 * 2
+placeholder_1 = &Kernel.*/2
+10 = Kernel.*(5, 2)
+placeholder_1 = &==/2
+true = :foo == :foo
+placeholder_1 = &Kernel.==/2
+true = Kernel.==(:foo, :foo)
+
+defmodule Placeholder_2 do
+  def placeholder_3(placeholder_4, placeholder_5) do
+    placeholder_1 = &UnknownModule.unknown_function/1
+    placeholder_1 = &placeholder_6/1
+    placeholder_1 = &Placeholder_2.placeholder_6/1
+    placeholder_1.(placeholder_4) && !placeholder_5
+  end
+
+  defp placeholder_6(placeholder_4) do
+    is_integer(placeholder_4)
+  end
+end

--- a/test_data/function_references/lib/input.ex
+++ b/test_data/function_references/lib/input.ex
@@ -1,0 +1,35 @@
+# Kernel functions should not get placeholders at all
+func = &is_integer/1
+true = is_integer(3)
+func = &Kernel.is_integer/1
+true = Kernel.is_integer(3)
+
+func = &+/2
+5 = 2 + 3
+func = &Kernel.+/2
+5 = Kernel.+(2, 3)
+
+func = &*/2
+10 = 5 * 2
+func = &Kernel.*/2
+10 = Kernel.*(5, 2)
+
+func = &==/2
+true = :foo == :foo
+func = &Kernel.==/2
+true = Kernel.==(:foo, :foo)
+
+# local functions get placeholders when defined, later their references get replaced with placeholders
+defmodule Foo do
+  def bar(x, y) do
+    func = &UnknownModule.unknown_function/1
+    func = &baz/1
+    func = &Foo.baz/1
+
+    func.(x) && !y
+  end
+
+  defp baz(x) do
+    is_integer(x)
+  end
+end


### PR DESCRIPTION
Bug found when working on https://github.com/exercism/elixir-representer/pull/100 because the representer would crash on this code:

```elixir
  def sum_of_squares(number) do
    Enum.reduce(1..number, 0, fn x, acc -> acc + x * x end)
  end

  def square_of_sum(number) do
    sum_to_number = Enum.reduce(1..number, &+/2)
    sum_to_number * sum_to_number
  end
```

The function reference `&+/2` would get rewritten as `&Placeholder_123/2`, and then `acc + x * x ` would get rewritten as `Placeholder_123(acc, x * x)` (not word for word, but conceptually). An uppercase function call is not valid, so the code formatter would crash on this.