### PR TITLE
Run on 1.19.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     container:
-      image: hexpm/elixir:1.19.2-erlang-28.1-debian-bookworm-20251103
+      image: hexpm/elixir:1.19.4-erlang-28.1-debian-bookworm-20251117
 
     steps:
       - name: Install git & jq

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.19.2-otp-28
+elixir 1.19.4-otp-28
 erlang 28.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.19.2-erlang-28.1-debian-bookworm-20251103 AS builder
+FROM hexpm/elixir:1.19.4-erlang-28.1-debian-bookworm-20251117 AS builder
 
 # Install SSL ca certificates
 RUN apt-get update && \
@@ -14,7 +14,7 @@ COPY . .
 # Builds an escript bin/elixir_representer
 RUN ./bin/build.sh
 
-FROM hexpm/elixir:1.19.2-erlang-28.1-debian-bookworm-20251103
+FROM hexpm/elixir:1.19.4-erlang-28.1-debian-bookworm-20251117
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /elixir-representer/bin /opt/representer/bin
 RUN apt-get update && \


### PR DESCRIPTION
I would like all tools to run on the same version (paranoia?) and the analyzer was merged with 1.19.4